### PR TITLE
Setup inicial proyecto Elixir/OTP

### DIFF
--- a/lib/last_train_to_tokio/application.ex
+++ b/lib/last_train_to_tokio/application.ex
@@ -1,0 +1,21 @@
+defmodule LastTrainToTokio.Application do
+  @moduledoc """
+  Main OTP application supervisor for Last Train to Tokyo.
+
+  This supervisor orchestrates all the core components of the distributed
+  banking simulation system.
+  """
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      # Main cluster supervisor will be added here
+      # {LastTrainToTokio.ClusterSupervisor, []}
+    ]
+
+    opts = [strategy: :one_for_one, name: LastTrainToTokio.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,15 +14,14 @@ defmodule LastTrainToTokio.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {LastTrainToTokio.Application, []}
     ]
   end
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,11 @@ defmodule LastTrainToTokio.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      # Will add more dependencies as needed when Erlang modules are available
+      # {:faker, "~> 0.18"},
+      # {:stream_data, "~> 1.1"},
+      # {:telemetry, "~> 1.2"},
+      # {:jason, "~> 1.4"}
     ]
   end
 end

--- a/test/last_train_to_tokio_test.exs
+++ b/test/last_train_to_tokio_test.exs
@@ -2,7 +2,7 @@ defmodule LastTrainToTokioTest do
   use ExUnit.Case
   doctest LastTrainToTokio
 
-  test "greets the world" do
-    assert LastTrainToTokio.hello() == :world
+  test "train conductor greeting" do
+    assert LastTrainToTokio.hello() == "Tsugi wa Shibuya desu. Doors will open on the left."
   end
 end


### PR DESCRIPTION
## Summary
- Configure proper OTP application with supervision tree
- Add Application module for managing the main supervisor
- Update mix.exs with application mod configuration
- Fix test suite to match expected behavior

## Changes
- Created `LastTrainToTokio.Application` module with basic supervisor setup
- Updated `mix.exs` to include `mod: {LastTrainToTokio.Application, []}`
- Fixed failing test in `test/last_train_to_tokio_test.exs`

## Test plan
- [x] `mix compile` runs successfully
- [x] `mix test` passes all tests
- [x] Application can start with `iex -S mix`

Resolves #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Application now starts under a supervisor for improved stability and resilience.
  - Updated greeting message to a train-style announcement.

- Tests
  - Adjusted test expectations to match the new greeting message.

- Chores
  - Configured the application entry point in the project settings.
  - Cleaned up commented dependency placeholders in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->